### PR TITLE
change in algo call

### DIFF
--- a/cartagen/enrichment/network/__init__.py
+++ b/cartagen/enrichment/network/__init__.py
@@ -1,6 +1,6 @@
 from cartagen.enrichment.network.branching_crossroads import detect_branching_crossroads
 from cartagen.enrichment.network.dead_ends import detect_dead_ends
 from cartagen.enrichment.network.dual_carriageways import detect_dual_carriageways
-from cartagen.enrichment.network.roundabouts import detect_roundabouts
+from cartagen.enrichment.network.roundabouts import detect_roundabouts, is_roundabout
 from cartagen.enrichment.network.rural_areas import rural_betweeness, rural_traffic
 from cartagen.enrichment.network.strokes import strokes_roads


### PR DESCRIPTION
Dans le plugin qgis, l'algo de détection de rond-point utilise la fonction is_roundabout, et non detect_roundabout. En "activant" is_roudabout dans le fichier _init_.py concerné dans la bibliothèque, on peut garder le fonctionnement actuel de l'algo sous qgis. Sinon je peux changer ce fonctionnement et utiliser "detect_roundabout" directement. 