### PR TITLE
changing li_openshaw

### DIFF
--- a/cartagen/utils/geometry/line.py
+++ b/cartagen/utils/geometry/line.py
@@ -312,14 +312,14 @@ def li_openshaw(line, cell_size):
     groups, squares = partition_grid(gdf, cell_size)
 
     simplified = []
-    previous = None
+    gi_alrd_done = []
     for i in range(0, len(vertexes)):
         index = None
         for gi, j in enumerate(groups):
             if i in j:
                 index = gi
         
-        if index is not None and index != previous:
+        if index is not None and index not in gi_alrd_done:
             group = groups[index]
             centroid = shapely.centroid(MultiPoint([ vertexes[v] for v in group ]))
             simplified.append(centroid)


### PR DESCRIPTION
Actuellement, certains centroïdes de cellules peuvent être calculés deux fois, ce qui fausse le résultat (la ligne obtenue en sortie pouvant passer plusieurs fois par le même sommet). Proposition de changement d'une condition pour éviter que cela n'arrive.